### PR TITLE
Updated README to include format of consumed JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Greater Chicago Food Depository - Frontend UI
 
+## Local API Key Configuration
+To protect any API keys during production they should not be hard-coded into the application. 
+Any API Keys should instead be stored at the root of the project directory in a .env file, which are already 
+setup to be ignored by git. Variables in a .env file can be accessed anywhere throught the app as: 
+
+    process.env.REACT_APP_API_VARIABLE_NAME.
+
+For more info on .env files: https://create-react-app.dev/docs/adding-custom-environment-variables/
+
+### API Keys and Corresponding Variable Names: 
+- MapBox: REACT_APP_MAPBOX_API_KEY
+
 ## JSON Format for data consumed by the frontend:
 Data for both counties and zipcodes should be in the form of a list of key,value pairs.
 of the corresponding data to that county.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
+# Greater Chicago Food Depository - Frontend UI
+
+## JSON Format for data consumed by the frontend:
+Data for both counties and zipcodes should be in the form of a list of key,value pairs.
+of the corresponding data to that county.
+
+### County Level Format: 
+The keys for counties should be the State + County FIPS codes in string format:
+State FIPS codes are two digits (Illinois' is "17") and the County FIPS codes are always 3 digits.
+Not all datasets will combine these two, so in processing data it may be necessary to do this step.
+In the example below, the first key is "17001" which equals Illinois + Adams County.
+
+    {
+        "17001": {
+            "metric_one": 1234,
+            "metric_two": 4321,
+            ...
+        }, 
+        "17002": {
+            "metric_one": 1234,
+            "metric_two": 4321,
+            ...
+        }, 
+        ...
+    }
+
+### Zipcode Level Format: 
+The keys for zipcodes should be the 5-digit long zipcode number in string format.
+
+    {
+        "60610": {
+            "metric_one": 1234,
+            "metric_two": 4321,
+            ...
+        }, 
+        "60611": {
+            "metric_one": 1234,
+            "metric_two": 4321,
+            ...
+        }, 
+        ...
+    }
+
+
+
+
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/src/Data/LayerStyles.js
+++ b/src/Data/LayerStyles.js
@@ -5,15 +5,9 @@
  * id = Used to filter or select a layer. 
  * type...  fill = layer object is outline and filled in
  *          line = layer object is outlined only
- * paint... 
- *      "fill" type:
- *          fill-color = color that fills in the layer object
- *          fill-opacity = how transparent the fill color is
- *          fill-outline-color = color of the outline
- *      "line" type:
- *          line-opacity = how transparent the outline is
- *          line-color = color of the outline
- *          line-width = width of outline
+ * 
+ * Descriptions of layer styling:
+ * https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/
  */
 
  import {highlight, countyFill, countyOutline, zipcodeFill, zipcodeOutline} from './Colors'


### PR DESCRIPTION
Updated the READEME to include the format for the JSON that's consumed by the frontend.

Two other small changes: 
- Added .DS_Store to the .gitignore file (.DS_Store are files related to Mac's file system, and are normally ignored)
- Added a link to the doc page for MapBox's layer styling.