### PR TITLE
[Don't Merge, Example] :alembic: Example with pie chart where its a reusable component

### DIFF
--- a/src/components/RightHandMenu/DonutChart/Donut.js
+++ b/src/components/RightHandMenu/DonutChart/Donut.js
@@ -4,17 +4,6 @@ import { PieChart, Pie, Cell } from 'recharts'
 import './Donut.css'
 import Legend from './Legend/Legend'
 
-// Mock Race Data; Similar Data should come in from Redux Slice
-const data = [
-  { key: 'White', value: 400 },
-  { key: 'Asian', value: 300 },
-  { key: 'Black', value: 300 },
-  { key: 'Hispanic/Latino', value: 200 },
-  { key: 'Pacific', value: 300 },
-  { key: 'Two+', value: 300 },
-  { key: 'Other', value: 200 }
-]
-
 // Color for various sectors in pie chart
 const COLORS = ['#2cba42', '#f3ad1c', '#534588', '#ff6833', '#92dbdd', '#ff0000', '#cc27b0']
 
@@ -28,7 +17,8 @@ const renderActiveShape = (props) => {
     outerRadius,
     fill,
     value,
-    name
+    name,
+    data
   } = props
 
   const myCalc = (midAngle, sin, sy) => {
@@ -63,7 +53,6 @@ const renderActiveShape = (props) => {
   const tx= ex + (cos >= 0 ? 1 : -1) * 12       //coordinates (tx,ty) on which text tag is placed
   const ty= ey + (sin >= 0 ? 1 : -1) * 16
 
-
   return (
     <g>
       {/* centers text in middle of pie chart */}
@@ -88,10 +77,10 @@ const renderActiveShape = (props) => {
         y={ty}
         textAnchor={textAnchor}
       >
-        <tspan 
+        <tspan
           fill='#1c752a'
           x={tx}
-          y={ty} >{`${data[name].key}`}</tspan>
+          y={ty} >{`${data[name].value}`}</tspan>
         <tspan
           className='tspan__val'
           x={tx + (cos >= 0 ? -1 : 1) * 6}
@@ -107,42 +96,57 @@ const renderActiveShape = (props) => {
  * for Race and similar type data
  * data slice filtered as per radioSelct and ToggleSelect to be used in place of mockData
  */
-function Donut() {
+function Donut(props) {
+  const {
+    data,
+    values,
+    calculateSum
+  } = props;
   const [legend, setLegend] = useState([])
   const [sum, setSum] = useState(0)
-
+  console.log('props', props)
   useEffect(() => {
     const l = []
-    let sum1 = data.reduce(function (a, b) {
-      return a + b.value
-    }, 0)
-    data.map((entry, index) => (l.push({ key : entry.key, color : COLORS[index % COLORS.length], value : entry.value  })))
-    setSum(sum1)
+    let sum1 = 0;
+    if (calculateSum) {
+      values.map(val => sum1 += data[val.field])
+    }
+    values.map(({name, field}, index) => (l.push({ key: name, color : COLORS[index % COLORS.length], value : data[field]  })))
+    if (calculateSum) {
+      setSum(sum1)
+    }
     setLegend( [...l])
   },[data])
+
+  const pieData = values.map(val => {
+    console.log('val', val.field)
+    console.log(data)
+    return ({ key: val.name, value: data[val.field] })
+  })
+  console.log('pieData', pieData)
 
   return (
     <div>
       <div className='donut__chart'>
-        <PieChart width={200} height={250}>
-          <Pie
-            data={data}
-            cx={100}
-            cy={125}
-            innerRadius={40}
-            outerRadius={55}
-            fill='#8884d8'
-            paddingAngle={1}
-            dataKey='value'
-            label={renderActiveShape}
-            labelLine={false}
-          >
-            {/* for each cell in pie fill color separate */}
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-            ))}
-          </Pie>
-        </PieChart>
+      <PieChart width={200} height={250}>
+        <Pie
+          data={pieData}
+          cx={100}
+          cy={125}
+          innerRadius={40}
+          outerRadius={55}
+          fill='#8884d8'
+          paddingAngle={1}
+          dataKey='value'
+          label={renderActiveShape}
+          labelLine={false}
+        >
+          {/* for each cell in pie fill color separate */}
+          {pieData.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+      </PieChart>
         <div className='donut__centerTxt'><h5>Total Population</h5><span>{sum}</span></div>
       </div>
       <Legend legend={legend} />

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -5,8 +5,16 @@ import ToggleSelect from './ToggleSelect/ToggleSelect'
 import RadioSelect from '../Utility/RadioSelect/RadioSelect'
 import Donut from './DonutChart/Donut'
 import UnequalDonut from './DonutChart/UnEqualDonut/UnequalDonut'
+import mockData from './mock_full_data'
 
 // Static Content to show in right hand menu
+const dataMap = {
+  'Census': {dataType: 'Census', dataOption: 'Census'},
+  'Food Insecurity 2018': {dataType: 'Food Insecurity', dataOption: 'Food Insecurity 2018'},
+  'Food Insecurity 2018 Children': {dataType: 'Food Insecurity', dataOption: 'Food Insecurity 2018 Children'},
+  'Poverty': {dataType: 'Poverty', dataOption: 'Poverty'},
+  'Poverty Children': {dataType: 'Poverty', dataOption: 'Poverty Children'}
+}
 const dataTypes = {
   Poverty : {
     title: 'Poverty Rates',
@@ -14,13 +22,13 @@ const dataTypes = {
     toggleSelect: ['Total', 'Children'],
     radioSelect: null
   },
-  Food_Insecurity : {
+  'Food Insecurity': {
     title: 'Food Insecurity',
     desc: 'Text about food insecurity rates and the data and possibly the next year',
     toggleSelect: ['Total', 'Children'],
     radioSelect: {
       Total : ['2018', '2020'],
-      Children : ['2018', '2020'] 
+      Children : ['2018', '2020']
     }
   },
   WIC : {
@@ -40,6 +48,73 @@ const dataTypes = {
   }
 }
 
+const dataOptions = {
+  'Food Insecurity 2018': {
+    calculateSum: false,
+    key: 'insecurity_data',
+    nestedKeys: ['insecurity_2018'],
+    values: [
+        {name: 'Food Insecurity', field: 'insecurity_2018'},
+        {name: 'Total Population', field: 'total'}
+      ]
+  },
+  'Food Insecurity 2018 Children': {
+    calculateSum: false,
+    key: 'insecurity_data',
+    nestedKeys: ['insecurity_2018_child'],
+    values: [
+        {name: 'Food Insecurity', field: 'insecurity_2018_child'},
+        {name: 'Total Population', field: 'total'}
+      ]
+  },
+  'Poverty': {
+    calculateSum: false,
+    key: 'poverty_data',
+    nestedKeys: ['poverty_percentages','poverty_population_poverty'],
+    values: [
+        {name: 'Overall Poverty', field: 'poverty_population_poverty'},
+        {name: 'Total Population', field: 'total'}
+      ]
+  },
+  'Poverty Children': {
+    calculateSum: false,
+    key: 'poverty_data',
+    nestedKeys: ['poverty_percentages', 'poverty_population_poverty_child'],
+    values: [
+        {name: 'Child Poverty', field: 'poverty_population_poverty_child'},
+        {name: 'Total Population', field: 'total'}
+      ]
+  },
+  'Census': {
+    calculateSum: true,
+    key: 'race_data',
+    values: [
+      {name: 'Asian', field: 'race_asian'},
+      {name: 'Black', field: 'race_black'},
+      {name: 'Hispanic/Latino', field: 'race_hispaniclatino_total'},
+      {name: 'White', field: 'race_white'},
+      {name: 'Native American', field: 'race_native'},
+      {name: 'Other', field: 'race_other'},
+      {name: 'Pacific', field: 'race_pacific'},
+      {name: 'Two+', field: 'race_twoplus_total'}
+    ]
+  }
+}
+
+const fetchData = (currentDataKey, nestedFields) => {
+  console.log('nestedFields', nestedFields)
+  let data = mockData[currentDataKey];
+  if (nestedFields) {
+    nestedFields.forEach(field => {
+      data = data[field]
+      console.log('data', data)
+    })
+    const dataKey = nestedFields[nestedFields.length-1]
+    data = {[dataKey]: data, 'total': 1-data}
+  }
+  return data
+}
+
 /*
  * COMPONENT: RightHandMenu
  */
@@ -56,46 +131,53 @@ const RightHandMenu = () => {
 
 
   const { data, county } = mockProps
+  const dataType = dataTypes[dataMap[data].dataType]
+  const dataOption = dataMap[data].dataOption
 
   // To keep track of which toggleSelect option is selected, so that respective radioSelect Options can be rendered
-  const initalToggleState = () => (dataTypes[data].toggleSelect ? dataTypes[data].toggleSelect[0] : null )
+  const initalToggleState = () => (dataType.toggleSelect ? dataType.toggleSelect[0] : null )
 
   const [toggSelected, setToggSelected] = useState(initalToggleState())
+  const currentDataKey = dataOptions[dataOption].key
+  const currentDataValues = dataOptions[dataOption].values
 
   return (
     <div>
       { county ? (
       <div className='rtMenu'>
         <div className='rtBody'>
-          <h1 className='rt__title'>{dataTypes[data].title}</h1>
-          <p className='rt__desc'>{dataTypes[data].desc}</p>
+          <h1 className='rt__title'>{dataType.title}</h1>
+          <p className='rt__desc'>{dataType.desc}</p>
           <h3 className='rt__name'>{county}</h3>
 
-          { dataTypes[data].toggleSelect ? (
+          { dataType.toggleSelect ? (
             <div className='rt__toggleSelect'>
-              <ToggleSelect data={dataTypes[data].toggleSelect} setToggSelected= {setToggSelected}/>
+              <ToggleSelect data={dataType.toggleSelect} setToggSelected= {setToggSelected}/>
             </div>
           ) : ''}
-          
-          { dataTypes[data].radioSelect ? (
+
+          { dataType.radioSelect ? (
             <div className='rt__radioSelect'>
-              <RadioSelect data={dataTypes[data].radioSelect[toggSelected]} handleChange={(idx) => console.log(idx)} alignment={'row'}/>
+              <RadioSelect data={dataType.radioSelect[toggSelected]} handleChange={(idx) => console.log(idx)} alignment={'row'}/>
             </div>
           ) : ''}
 
           {/* WIC data and Census Data has race type pie chart; others have a different pie chart */}
           <div className='rt__donut'>
-            {(data === 'WIC' || data === 'Census') ? <Donut /> : <UnequalDonut />}    
+              <Donut
+                data={fetchData(currentDataKey, dataOptions[dataOption].nestedKeys)}
+                values={currentDataValues}
+                calculateSum={dataOptions[dataOption].calculateSum}/>
           </div>
         </div>
         <div className='rt__footer'>
-          <a alt='link to surce' href='#a' className='rt__link'>Link to source</a>  
+          <a alt='link to surce' href='#a' className='rt__link'>Link to source</a>
         </div>
       </div>
     ) : (
       <div className='rtMenu noCounty'><p className='rt__noCounty'>Select a county to view {data}</p></div>
     )}
-    </div> 
+    </div>
   )
 }
 export default RightHandMenu

--- a/src/components/RightHandMenu/mock_full_data.js
+++ b/src/components/RightHandMenu/mock_full_data.js
@@ -1,0 +1,81 @@
+const mockData = {
+  NAME: "Adams County, Illinois",
+  insecurity_data: {
+    insecurity_2018: 0.102,
+    insecurity_2018_child: 0.142,
+    insecurity_2020_child_projected: 0.206,
+    insecurity_2020_projected: 0.135
+  },
+  poverty_data: {
+    poverty_percentages: {
+      poverty_population_poverty: 0.12143,
+      poverty_population_poverty_child: 0.036781
+    },
+    poverty_population_poverty: 7874,
+    poverty_population_poverty_child: 2385,
+    poverty_population_total: 64844
+  },
+  race_data: {
+    race_asian: 540,
+    race_black: 2676,
+    race_hispaniclatino_total: 1021,
+    race_majority: "race_white",
+    race_native: 178,
+    race_other: 72,
+    race_pacific: 42,
+    race_percentages: {
+      race_asian: 0.008129,
+      race_black: 0.040285,
+      race_hispaniclatino_total: 0.01537,
+      race_native: 0.00268,
+      race_other: 0.001084,
+      race_pacific: 0.000632,
+      race_twoplus_total: 0.013383,
+      race_white: 0.918437
+    },
+    race_total: 66427,
+    race_twoplus_total: 889,
+    race_white: 61009
+  },
+  wic_participation_children_data: {
+    hispanic_or_latino: 20,
+    race_amer_indian_or_alaskan_native: 3,
+    race_asian: 1,
+    race_black: 97,
+    race_multiracial: 51,
+    race_native_hawaii_or_pacific_islander: 3,
+    race_white: 322,
+    total: 365
+  },
+  wic_participation_infants_data: {
+    hispanic_or_latino: 19,
+    race_amer_indian_or_alaskan_native: 1,
+    race_asian: 3,
+    race_black: 54,
+    race_multiracial: 38,
+    race_native_hawaii_or_pacific_islander: 3,
+    race_white: 216,
+    total: 237
+  },
+  wic_participation_total_data: {
+    hispanic_or_latino: 44,
+    race_amer_indian_or_alaskan_native: 4,
+    race_asian: 6,
+    race_black: 172,
+    race_multiracial: 95,
+    race_native_hawaii_or_pacific_islander: 8,
+    race_white: 697,
+    total: 780
+  },
+  wic_participation_women_data: {
+    hispanic_or_latino: 5,
+    race_amer_indian_or_alaskan_native: 0,
+    race_asian: 2,
+    race_black: 21,
+    race_multiracial: 6,
+    race_native_hawaii_or_pacific_islander: 2,
+    race_white: 159,
+    total: 178
+  }
+};
+  export default mockData;


### PR DESCRIPTION
This is super messy code but - on the right hand menu if you input the following as "data":

- Poverty
- Poverty Children
- Food Insecurity 2018
- Food Insecurity 2018 Children
- Census

You can see the pie chart update for each dataset. It's using example mock data - this data would in theory be stored in a Redux store. The one that I didn't tackle is WIC data - I think that we might need to talk to the backend team about how they send that data to us. Right now we have to write a custom function to show total enrollment broken down by age, maybe we should just get that in the data directly.