### PR TITLE
Invert left menu positions

### DIFF
--- a/src/components/LeftHandMenu/LeftHandMenu.css
+++ b/src/components/LeftHandMenu/LeftHandMenu.css
@@ -1,8 +1,6 @@
 .left-menu {
   display: flex;
   flex-direction: column;
-  display: flex;
-  flex-direction: column;
   justify-content: space-between;
   height: 100vh;
 }

--- a/src/components/LeftHandMenu/LeftHandMenu.js
+++ b/src/components/LeftHandMenu/LeftHandMenu.js
@@ -8,9 +8,9 @@ import './LeftHandMenu.css'
 function LeftHandMenu() {
 	return (
 		<div className="left-menu">
-			<ZoomToBoundsMenu />
-			<DatasetSelector />
+      <DatasetSelector />
 			<ExtraDataMenu />
+			<ZoomToBoundsMenu />
 		</div>
 	);
 }


### PR DESCRIPTION
[ticket](https://trello.com/c/tV62zFv2/142-user-can-view-the-datasets-available-to-them-before-they-select-a-county)

Inverted the left menu components and removed redundant css.