### PR TITLE
Update census copy to race and ethnicity

### DIFF
--- a/src/components/LeftHandMenu/DatasetSelector/DatasetSelector.js
+++ b/src/components/LeftHandMenu/DatasetSelector/DatasetSelector.js
@@ -12,7 +12,7 @@ function DatasetSelector(props) {
 
 	// Radio Options to select feature for data display
 	const featOptions = {
-		featNames: ['Poverty Rates','Food Insecurity','WIC Usage','Snap Usage','Census',],
+		featNames: ['Poverty Rates','Food Insecurity','WIC Usage','Snap Usage', 'Race/Ethnicity'],
 		featKeys: ['poverty_data', 'insecurity_data', 'WIC', 'snap_data', 'race_data']
 	}
 

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -49,7 +49,16 @@ const RightHandMenu = () => {
       { selectedCounty && dataOptions[selectedfilterFeat] ? (
       <div className='rtMenu'>
         <div className='rtBody'>
-          <h1 className='rt__title'>{dataOptions[selectedfilterFeat].title}</h1>
+          <h1 className='rt__title'>
+            {dataOptions[selectedfilterFeat].title === 'Race/Ethnicity' ? (
+              <>
+                Race/Ethnicity
+                <span style={{ fontSize: '.85rem' }}> (Census)</span>
+              </>
+            ) : (
+              dataOptions[selectedfilterFeat].title
+            )}
+          </h1>
           <p className='rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
           <h3 className='rt__name'>{selectedCounty ? selectedCounty.name + ' County' : ''}</h3>
 

--- a/src/components/RightHandMenu/dataOptions.js
+++ b/src/components/RightHandMenu/dataOptions.js
@@ -38,7 +38,7 @@ export const dataOptions = {
     dataType: 'value'
   },
   race_data : {
-    title: 'Census Data',
+    title: 'Race/Ethnicity',
     desc: 'Text about Census data and the data and possibly the next year',
     toggleSelect: null,
     radioSelect: null,

--- a/src/components/Utility/RadioSelect/RadioSelect2.js
+++ b/src/components/Utility/RadioSelect/RadioSelect2.js
@@ -35,7 +35,17 @@ function RadioSelect2(props) {
                    checked={selectFeat===idx} 
                    onChange={() => handleChange(idx)}>
             </input>
-            <h3 className='radioLabel'>{feature}</h3>
+            <h3 className='radioLabel'>
+              {feature === 'Race/Ethnicity' ? (
+                  <>
+                    Race/Ethnicity
+                    <span style={{ fontSize: '.65rem' }}> (Census)</span>
+                  </>
+                ) : (
+                  feature
+                )
+              }
+            </h3>
           </label>
         ))
       ): ''}


### PR DESCRIPTION
[ticket](https://trello.com/c/2mxIRxHV/143-user-can-convey-that-a-dataset-they-can-chose-from-is-race-ethnicity-from-census-data)

Updated "Census" in DatasetSelector.js and "Census Data" in the RightHandMenu.js to "Race/Ethnicity (Census)". I was unsure of the best way to make (Census) a smaller font size than "Race/Ethnicity". My solution works, but it's not elegant. 