### PR TITLE
Increase map color legend size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,31 +76,43 @@ align-items: center;
 
 
 /****Legend Styles (other than font styles)****/
-.map-color-legend{
+.map-color-legend {
+  width: 240px;
+  display: flex;
+  flex-direction: column;
   position: absolute;
   bottom: 50px; 
   left: 50px;
   background-color: var(--component-background-color);
   font-family:'futura-pt';   /*Should we just define this for the whole body?*/
   color: var(--primary-font-color);
-  font-size: 0.8125rem;
-  padding: 4px 0 4px 10px;
-  line-height: 1.8;
+  font-size: 0.75rem;
   box-shadow: 0px 1px 4px #00000029;
   border: 1px solid var(--component-border-color);
+  border-radius: 10px;
 }
+
+.map-color-legend .color-key {
+  margin: 8px 0px 8px 20px;
+  font-size: 0.875rem;
+}
+
 .map-color-legend .bin-container{
   display: flex;
   justify-content: space-evenly;
-  font-size: 0.625rem;
 }
-.map-color-legend .bin{
-  margin-right: 8px;
+
+.map-color-legend .bin {
+  display: flex;
+  flex-direction: column;
 }
+
 .map-color-legend .bin-color-sample{
   height: 40px;
   width: 40px;
 }
+
 .map-color-legend .bin-label{
-  white-space: nowrap; 
+  margin-top: 2px;
+  margin-bottom: 8px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -98,8 +98,8 @@ align-items: center;
   margin-right: 8px;
 }
 .map-color-legend .bin-color-sample{
-  height: 28px;
-  width: 30px;
+  height: 40px;
+  width: 40px;
 }
 .map-color-legend .bin-label{
   white-space: nowrap; 

--- a/src/components/MapColorLegend.js
+++ b/src/components/MapColorLegend.js
@@ -37,7 +37,7 @@ function MapColorLegend(props) {
 
   return !colors ? null : (
     <div class="map-color-legend clearfix" >
-      <span>Color Key</span>
+      <span class="color-key">Color Key</span>
       <div class="bin-container">
         {colors.map((color, i) => {
           return (


### PR DESCRIPTION
[ticket](https://trello.com/c/LSMQ1RqD/141-user-can-view-the-legend-more-clearly)

I updated the styling of `MapColorLegend` to the specs in the Trello card and the Xd file. I was able to get it pretty close except I couldn't change the `Color Key` font to bold. Maybe it needs to be imported?