### PR TITLE
Adjust line under select a county

### DIFF
--- a/src/components/LeftHandMenu/ZoomToBoundsMenu.css
+++ b/src/components/LeftHandMenu/ZoomToBoundsMenu.css
@@ -13,7 +13,6 @@
 
 .title {
   padding: 16px 0 16px 0;
-  height: calc(100vh - 210px);
   width: 100%;
   color: #059713; 
   background: #fff;

--- a/src/components/LeftHandMenu/ZoomToBoundsMenu.css
+++ b/src/components/LeftHandMenu/ZoomToBoundsMenu.css
@@ -34,7 +34,7 @@ button {
   text-align: center;
   color: #059713; 
   background: #fff;
-  border-bottom: 1px solid #F3AD1C;
+  border-bottom: 1px solid #CED4DA !important;
   border-right: none;
   border-top: none;
   border-left: none;


### PR DESCRIPTION
[ticket](https://trello.com/c/IKc4J75a/157-county-selection-list-container-is-not-static-when-resizing-the-screen)

Removed css that was causing the "Select a County" title to resize based on window size. Also changed the county button border color to the grey color as per Allie's Xd design.