### PR TITLE
Default to Total on WIC - Race Secondary Dataset Dropdown (not Women)

### DIFF
--- a/src/components/RightHandMenu/dataOptions.js
+++ b/src/components/RightHandMenu/dataOptions.js
@@ -32,8 +32,9 @@ export const dataOptions = {
     legendLabels: ['Total Enrollment', ''],
     radioSelect: {
       Enrollment : null,
-      Race : ['Women', 'Infants', 'Children', 'Total'],
-      RaceKeys: ['wic_participation_women_data', 'wic_participation_infants_data', 'wic_participation_children_data', 'wic_participation_total_data']
+      Race : ['Total', 'Women', 'Infants', 'Children'],
+      RaceKeys: ['wic_participation_total_data',
+        'wic_participation_women_data', 'wic_participation_infants_data', 'wic_participation_children_data']
       },
     dataType: 'value'
   },


### PR DESCRIPTION
[ticket](https://trello.com/c/x4YxV2wm/173-default-to-total-on-wic-race-secondary-dataset-dropdown-not-women)

Changed default value to be "Total" in WIC dropdown in the right-hand menu. 