### PR TITLE
Updated styles

### DIFF
--- a/src/AllieAwesomeCSS.css
+++ b/src/AllieAwesomeCSS.css
@@ -1,5 +1,11 @@
 /* FONTS */
 
+.font-large {
+    font: normal normal bold 1.5rem/1.5rem 'Hind';
+    letter-spacing: 0px;
+    opacity: 1;
+}
+
 /* Used in:
     * Card headers
     * Titles

--- a/src/components/ExtraDataRightMenu/ExtraDataMenu.css
+++ b/src/components/ExtraDataRightMenu/ExtraDataMenu.css
@@ -1,9 +1,7 @@
 
 .extraData-title {
 	margin: 0.5rem auto 0.5rem 1.2rem;
-	font: normal normal normal 1rem/1.3125rem futura-pt, sans-serif;
 	letter-spacing: 0px;
-	color: #1c752a;
 	opacity: 1;
 	margin-left: 0;
 }

--- a/src/components/ExtraDataRightMenu/ExtraDataMenu.js
+++ b/src/components/ExtraDataRightMenu/ExtraDataMenu.js
@@ -22,7 +22,7 @@ function ExtraDataMenu(props) {
 	/* Don't load this bar if there are no dataset options */  
 	return (radioSelect && selectedCounty) ? (
     <div className="extraData-wrapper font-normal">
-			<h3 className="extraData-title">Show data for:</h3>
+			<h3 className="extraData-title font-bold primary-color">Show data for:</h3>
       <Dropdown 
         arrowClassName='arrow'
         options={radioSelect[toggSelected]} 

--- a/src/components/RightHandMenu/DonutChart/Legend/Legend.css
+++ b/src/components/RightHandMenu/DonutChart/Legend/Legend.css
@@ -4,10 +4,6 @@
  
 .leg__title {
   margin: 0.5rem auto 0.5rem 1.2rem;
-  font: normal normal normal 1rem/1.3125rem futura-pt, sans-serif;
-  letter-spacing: 0px;
-  color: #1c752a;
-  opacity: 1;
   margin-left: 0;
 }
 

--- a/src/components/RightHandMenu/DonutChart/Legend/Legend.css
+++ b/src/components/RightHandMenu/DonutChart/Legend/Legend.css
@@ -15,6 +15,8 @@
    align-items: center;
    border-top: 1px solid #CED4DA;
    padding: 4px 0px 4px 6px;
+   width: 297px;
+   margin-left: -16px;
  }
 
  .leg__item:last-child {
@@ -29,18 +31,14 @@
  .leg__left {
    display: flex;
    align-items: center;
+   margin-left: 2rem;
  }
  
  .leg__color {
    width: 15px;
    height: 15px;
    border-radius: 3px;
-   margin-right: 10px;
- }
- 
- .leg__name {
-   font-size: 12px;
-   font-weight: 800;
+   margin-right: 1rem;
  }
  
  .leg__rt {
@@ -48,6 +46,7 @@
    font-weight: 600;
    float: right;
    white-space: nowrap;
+   margin-right: 2rem;
    /* overflow: scroll; */
  }
  

--- a/src/components/RightHandMenu/DonutChart/Legend/Legend.js
+++ b/src/components/RightHandMenu/DonutChart/Legend/Legend.js
@@ -11,7 +11,7 @@ let getDisplayValue;
 function Legend(props) {
   return (
     <div className="legend">
-      <h3 className="leg__title">
+      <h3 className="leg__title font-bold primary-color">
         {props.legend[0] && props.legend[0].key === "Food Insecurity"
           ? "Out of Total Population:"
           : "Select data to display:"}

--- a/src/components/RightHandMenu/DonutChart/Legend/Legend.js
+++ b/src/components/RightHandMenu/DonutChart/Legend/Legend.js
@@ -46,7 +46,7 @@ function LegendItem({legendItem, index, displayValue}) {
             className="leg__color"
             style={{backgroundColor: item.color}}
           ></div>
-          <div className="leg__name">{item.key}</div>
+          <div className="font-normal primary-color">{item.key}</div>
         </div>
         <div className="leg__rt">{displayValue}</div>
       </>
@@ -60,7 +60,7 @@ function LegendItem({legendItem, index, displayValue}) {
           disabled="true"
           style={{backgroundColor: "lightgrey"}}
         ></div>
-        <div className="leg__name" disabled="true" style={{color: "lightgrey"}}>
+        <div className="font-normal primary-color" disabled="true" style={{color: "lightgrey"}}>
           {item.key}
         </div>
       </div>
@@ -75,6 +75,6 @@ getDisplayValue = (item, dataType) =>
   dataType === "percentValue"
     ? `${item.value} (${item.percent}%)`
     : dataType === "percent"
-    ? item.value + " %?"
+    ? item.value + " %"
     : item.value;
 export default Legend;

--- a/src/components/RightHandMenu/LinkToSource/LinkToSource.css
+++ b/src/components/RightHandMenu/LinkToSource/LinkToSource.css
@@ -1,6 +1,6 @@
 .rt__link {
   color: black;
-  font-size: 8px;
+  font-size: 0.5rem;
   font-family: "Hind";
   text-decoration: underline;
 }

--- a/src/components/RightHandMenu/LinkToSource/LinkToSource.css
+++ b/src/components/RightHandMenu/LinkToSource/LinkToSource.css
@@ -1,7 +1,6 @@
 .rt__link {
   color: black;
-  font-size: 10px;
-  padding-left: 5px;
-  font-weight: 500;
+  font-size: 8px;
+  font-family: "Hind";
   text-decoration: underline;
 }

--- a/src/components/RightHandMenu/RightHandMenu.css
+++ b/src/components/RightHandMenu/RightHandMenu.css
@@ -21,6 +21,7 @@
 }
 
 .rt__desc {
+  margin-top: 8px;
   padding-left: 4px;
 }
 

--- a/src/components/RightHandMenu/RightHandMenu.css
+++ b/src/components/RightHandMenu/RightHandMenu.css
@@ -26,8 +26,6 @@
 }
 
 .rt__name {
-  font-size: 14px;
-  font-weight: 800;
   text-align: center;
   padding: 12px;
 }

--- a/src/components/RightHandMenu/RightHandMenu.css
+++ b/src/components/RightHandMenu/RightHandMenu.css
@@ -54,5 +54,4 @@
 .rt__noCounty {
   text-align: center;
   padding: 20px;
-  font-weight: 700;
 }

--- a/src/components/RightHandMenu/RightHandMenu.css
+++ b/src/components/RightHandMenu/RightHandMenu.css
@@ -21,9 +21,7 @@
 }
 
 .rt__desc {
-  color: black;
-  font-size: 10px;
-  font-weight: 600;
+  padding-left: 4px;
 }
 
 .rt__name {

--- a/src/components/RightHandMenu/RightHandMenu.css
+++ b/src/components/RightHandMenu/RightHandMenu.css
@@ -6,7 +6,7 @@
   border-radius: 9px;
   color: #1c752a;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 0.1px;
-  padding: 12px;
+  padding: 12px 12px 8px 16px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -22,7 +22,6 @@
 
 .rt__desc {
   margin-top: 8px;
-  padding-left: 4px;
 }
 
 .rt__name {
@@ -35,8 +34,6 @@
 }
 
 .rt__footer {
-  margin-top: 20px;
-  border-top: 1px solid #f9d68d;
   width: 100%;
   align-self: center;
 }

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -70,10 +70,10 @@ const RightHandMenu = () => {
         <div className='rtMenu'>
           <div className='rtBody'>
             {dataOptions[selectedfilterFeat].title === 'Race/Ethnicity' ? (
-                <CardHeader text={"Race/Ethnicity"} styleOverride={{ width: "297px", marginLeft: "-12px"}} />
+                <CardHeader text={"Race/Ethnicity"} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
               ) : (
                 <CardHeader text={
-                  dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px"}} />
+                  dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
               )}
             <p className='rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
             <h3 className='rt__name'>

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -76,7 +76,7 @@ const RightHandMenu = () => {
                   dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
               )}
             <p className='font-small black rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
-            <h3 className='rt__name'>
+            <h3 className='rt__name font-bold primary-color'>
               {selectedCounty ? selectedCounty.name + ' County' : ''}
             </h3>
 

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -75,7 +75,7 @@ const RightHandMenu = () => {
                 <CardHeader text={
                   dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
               )}
-            <p className='rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
+            <p className='font-small black rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
             <h3 className='rt__name'>
               {selectedCounty ? selectedCounty.name + ' County' : ''}
             </h3>

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -12,6 +12,7 @@ import {filterFeatChart} from '../Utility/filterFeatChart'
 import {dataOptions} from './dataOptions'
 import {DataContext} from '../../App'
 import '../../AllieAwesomeCSS.css'
+import CardHeader from '../Utility/CardHeader/CardHeader'
 
 /*
  * COMPONENT: RightHandMenu
@@ -68,16 +69,12 @@ const RightHandMenu = () => {
       {selectedCounty && dataOptions[selectedfilterFeat] ? (
         <div className='rtMenu'>
           <div className='rtBody'>
-            <h1 className='rt__title'>
-              {dataOptions[selectedfilterFeat].title === 'Race/Ethnicity' ? (
-                <>
-                  Race/Ethnicity
-                  <span style={{ fontSize: '.85rem' }}> (Census)</span>
-                </>
+            {dataOptions[selectedfilterFeat].title === 'Race/Ethnicity' ? (
+                <CardHeader text={"Race/Ethnicity"} styleOverride={{ width: "297px", marginLeft: "-12px"}} />
               ) : (
-                dataOptions[selectedfilterFeat].title
+                <CardHeader text={
+                  dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px"}} />
               )}
-            </h1>
             <p className='rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
             <h3 className='rt__name'>
               {selectedCounty ? selectedCounty.name + ' County' : ''}

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -11,6 +11,7 @@ import LinkToSource from './LinkToSource/LinkToSource'
 import {filterFeatChart} from '../Utility/filterFeatChart'
 import {dataOptions} from './dataOptions'
 import {DataContext} from '../../App'
+import '../../AllieAwesomeCSS.css'
 
 /*
  * COMPONENT: RightHandMenu
@@ -126,7 +127,7 @@ const RightHandMenu = () => {
         </div>
       ) : (
         <div className='rtMenu noCounty'>
-          <p className='rt__noCounty'>
+          <p className='rt__noCounty font-large'>
             Select a county to view {dataOptions[selectedfilterFeat].title}
           </p>
         </div>

--- a/src/components/RightHandMenu/RightHandMenu.js
+++ b/src/components/RightHandMenu/RightHandMenu.js
@@ -70,10 +70,10 @@ const RightHandMenu = () => {
         <div className='rtMenu'>
           <div className='rtBody'>
             {dataOptions[selectedfilterFeat].title === 'Race/Ethnicity' ? (
-                <CardHeader text={"Race/Ethnicity"} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
+                <CardHeader text={"Race/Ethnicity"} styleOverride={{ width: "297px", marginLeft: "-16px", marginTop: "-12px"}} />
               ) : (
                 <CardHeader text={
-                  dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-12px", marginTop: "-12px"}} />
+                  dataOptions[selectedfilterFeat].title} styleOverride={{ width: "297px", marginLeft: "-16px", marginTop: "-12px"}} />
               )}
             <p className='font-small black rt__desc'>{dataOptions[selectedfilterFeat].desc}</p>
             <h3 className='rt__name font-bold primary-color'>
@@ -124,7 +124,7 @@ const RightHandMenu = () => {
         </div>
       ) : (
         <div className='rtMenu noCounty'>
-          <p className='rt__noCounty font-large'>
+          <p className='rt__noCounty font-large primary-color'>
             Select a county to view {dataOptions[selectedfilterFeat].title}
           </p>
         </div>

--- a/src/components/Utility/CardHeader/CardHeader.js
+++ b/src/components/Utility/CardHeader/CardHeader.js
@@ -3,8 +3,17 @@ import './CardHeader.css';
 import './../../../AllieAwesomeCSS.css';
 
 function CardHeader(props) {
+
+	let styles;
+
+	// Allows for the component to receive "override styles" that will be added on an element level.
+	// So although the component has class level styling, this can be tweaked when needed.
+	if(props.styleOverride) {
+		styles = {...props.styleOverride};
+	}
+
 	return (
-		<div className="cardheader-container">
+		<div className="cardheader-container" style={styles}>
 			<h3 className="font-bold primary-color">{props.text}</h3>
 		</div>
 	);


### PR DESCRIPTION
This PR aimed to make the Right Hand menu look like the Adobe Mapping Project V3 wireframe by changing fonts and some other styling.

[Ticket](https://trello.com/c/IKiytGGY)

Things that have changed:
- Fonts in description, headers, "Legend" are replaced
- Margins are more in line with sketch
- Lines are more in line with sketch
- CardHeader component made more flexible (but also implemented for the last time)

What has not received work?
- Dropdown menu has not been changed
- Tooltip / Donut chart fonts are not updated.
- "Slider" between Total / Children has not been changed