### PR TITLE
Fix Various Warnings from Inspect Window

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,7 @@
-import React, {useEffect} from "react";
-import {useDispatch} from "react-redux";
-
+import React from "react";
 
 import RightHandMenu from "./components/RightHandMenu/RightHandMenu";
 import Map from "./mapbox/Map";
-import MapColorLegend from "./components/MapColorLegend";
 import LeftHandMenu from "./components/LeftHandMenu/LeftHandMenu";
 import "./App.css";
 

--- a/src/components/LeftHandMenu/ZoomToBoundsMenu.js
+++ b/src/components/LeftHandMenu/ZoomToBoundsMenu.js
@@ -8,7 +8,6 @@ import {DataContext} from '../../App'
 
 import './ZoomToBoundsMenu.css'
 import CardHeader from '../Utility/CardHeader/CardHeader';
-import { selectedCounty } from '../../mapbox/LayerStyles';
 
 /**
  * COMPONENT: ZoomToBoundsMenu
@@ -84,7 +83,7 @@ export const ZoomToBoundsButton = ({keyValue, label, newViewport, countyID}) => 
     const selectedFeat = useSelector(state => state.selectedFeat)
     const filters = useSelector(state => state.filters)
 
-    const { selectedCounty, selectedfilterFeat } = selectedFeat;
+    const { selectedCounty } = selectedFeat;
     
     const onZoomToBoundsButtonClick = (vp, keyValue, countyID) => {
         const currentCounty = {

--- a/src/components/MapColorLegend.js
+++ b/src/components/MapColorLegend.js
@@ -5,7 +5,6 @@ import {mapColors, categoryOpacityGroup} from "../mapbox/Colors";
 import {getExtraDataLabelDictionary} from "../mapbox/DataSelectionUtil";
 
 import {
-  extractCountyAndMetricDictionary,
   getDataForSelector,
 } from "../mapbox/ExtractCountyDataUtil";
 

--- a/src/mapbox/CountyColorsUtil.js
+++ b/src/mapbox/CountyColorsUtil.js
@@ -251,16 +251,3 @@ ${JSON.stringify({selectedfilterFeat, selectedfilterSubfeat , selectedExtraDataF
   };
   */
 }
-
-function getScaledLightnessLevel({
-  value,
-  maxValue = 1,
-  minValue = 0,
-  maxLightness,
-  minLightness,
-}) {
-  //lightness from the hsl() color in css
-  const percent = value / (maxValue - minValue);
-  const range = maxLightness - minLightness;
-  return percent * range + minLightness;
-}

--- a/src/mapbox/CountyLayer.js
+++ b/src/mapbox/CountyLayer.js
@@ -2,7 +2,7 @@ import React, {useContext, useMemo, useEffect} from 'react'
 import {Source, Layer} from 'react-map-gl';
 import { useSelector, useDispatch } from 'react-redux'
 import {mapColors,categoryOpacityGroup} from "./Colors"
-import {selectedCounty, hoverCounty, county} from './LayerStyles';
+import {selectedCounty, hoverCounty} from './LayerStyles';
 import {setSelectionDefaults} from './MapSelectionDefaults';
 
 import {DataContext} from '../App'

--- a/src/mapbox/DataSelectionUtil.js
+++ b/src/mapbox/DataSelectionUtil.js
@@ -24,7 +24,6 @@ export function getFilterFeaturesFromSelection({
   extraDataMenuLabel = null,
   selectedCounty = null,
 }) {
-  const featOptions = getFeatOptions();
   const labelToFeatureDicitonary = {
     Census: "race_data",
     "WIC Usage": "wic_participation",

--- a/src/mapbox/ExtractCountyDataUtil.js
+++ b/src/mapbox/ExtractCountyDataUtil.js
@@ -28,7 +28,7 @@ export function extractCountyAndMetricDictionary(
   if( Object.values(countyMetricDict).includes(undefined)){
       const newSelectedDataFeature =  getExtraDataLabelDictionary(selectedfilterFeat)[selectedExtraDataFeatLabel]
       if(newSelectedDataFeature === selectedExtraDataFeatLabel){
-          throw new Error(`County metric is undefind for ${selectedfilterFeat,extraDataMenuFeat,selectedExtraDataFeatLabel}`)
+          throw new Error(`County metric is undefind for ${selectedfilterFeat} ${extraDataMenuFeat} ${selectedExtraDataFeatLabel}`)
       }
       selectedExtraDataFeat=  getExtraDataLabelDictionary(selectedfilterFeat)[selectedExtraDataFeatLabel]
       return  extractCountyAndMetricDictionary(selectedFeat, { selectedExtraDataFeat }, countyData)
@@ -56,18 +56,15 @@ export function getDataForSelector({
             : "poverty_population_total"
 
         return currentObjectToSearch[selectedfilterFeat][selectedfilterSubfeat];
-        break;
 
       case "insecurity_data":
         selectedfilterSubfeat =
           selectedfilterSubfeat || "insecurity_2018_child";
         return currentObjectToSearch[selectedfilterFeat][selectedfilterSubfeat];
-        break;
 
       case "race_data":
         selectedExtraDataFeat = selectedExtraDataFeat || "race_asian";
         return currentObjectToSearch[selectedfilterFeat][selectedExtraDataFeat];
-        break;
 
       case "snap_data":
         selectedfilterSubfeat = selectedfilterSubfeat || "2019age_18-65";

--- a/src/mapbox/LayerStyles.js
+++ b/src/mapbox/LayerStyles.js
@@ -10,7 +10,7 @@
  * https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/
  */
 
- import {highlight, countyFill, countyOutline, zipcodeFill, zipcodeOutline} from './Colors'
+ import {highlight, zipcodeFill, zipcodeOutline} from './Colors'
 
 /**
  * Base styling for county layer objects

--- a/src/mapbox/MapSelectionDefaults.js
+++ b/src/mapbox/MapSelectionDefaults.js
@@ -63,5 +63,7 @@ export function setSelectionDefaults({
       setSubFeature(defaultFeatures.wic_feature);
       setExtraDataFeatureDefault(defaultFeatures.wic_race);
       break;
+    default:
+      throw new Error(`Unexpected selected filter feature ${selectedfilterFeat}`);
   }
 }


### PR DESCRIPTION
I didn't fix the "react-hooks/exhaustive-deps" warnings because when I tried that out, the app started spewing log messages like "No selectedfilterFeat" and I don't have much experience with React so I didn't know what exactly was wrong.

src\App.js
  Line 1:16:  'useEffect' is defined but never used       no-unused-vars
  Line 2:9:   'useDispatch' is defined but never used     no-unused-vars
  Line 7:8:   'MapColorLegend' is defined but never used  no-unused-vars

src\components\LeftHandMenu\ZoomToBoundsMenu.js
  Line 11:10:  'selectedCounty' is defined but never used               no-unused-vars
  Line 87:29:  'selectedfilterFeat' is assigned a value but never used  no-unused-vars

src\components\MapColorLegend.js
  Line 8:3:  'extractCountyAndMetricDictionary' is defined but never used  no-unused-vars

src\mapbox\CountyColorsUtil.js
  Line 255:10:  'getScaledLightnessLevel' is defined but never used  no-unused-vars

src\mapbox\CountyLayer.js
  Line 5:38:  'county' is defined but never used                                                                                                         no-unused-vars

src\mapbox\DataSelectionUtil.js
  Line 27:9:  'featOptions' is assigned a value but never used  no-unused-vars

src\mapbox\ExtractCountyDataUtil.js
  Line 31:78:  Unexpected use of comma operator  no-sequences
  Line 59:9:   Unreachable code                  no-unreachable
  Line 65:9:   Unreachable code                  no-unreachable
  Line 70:9:   Unreachable code                  no-unreachable

src\mapbox\LayerStyles.js
  Line 13:21:  'countyFill' is defined but never used     no-unused-vars
  Line 13:33:  'countyOutline' is defined but never used  no-unused-vars

src\mapbox\MapSelectionDefaults.js
  Line 48:3:  Expected a default case  default-case